### PR TITLE
Add missing field markers for variants & text areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Add these strings into the value (or key) for added magic. Not all of these work
 * "[p]": limit display to products only
 * "[v]": limit display to product variants only
 
+* "[_t]": mark as a text area field
 * "[_c]": mark as a collection field
 * "[_f]": mark as a file field
 * "[_i]": mark as an integer field

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Add these strings into the value (or key) for added magic. Not all of these work
 * "[g]": limit display to pages only
 * "[o]": limit display to orders only
 * "[p]": limit display to products only
+* "[v]": limit display to product variants only
 
 * "[_c]": mark as a collection field
 * "[_f]": mark as a file field


### PR DESCRIPTION
Didn't realize this was missing until I saw the warning in the Shopify admin saying `[v]` was needed to assign fields to variants.